### PR TITLE
grunt-sass-globbing fix for scss auto import issue

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -18,8 +18,15 @@ window.AuthService = (function(){
         unsubscribe();
     });
 
-    function requestAuth(){
-        return firebase.auth().signInWithPopup(provider).then(function(result) {
+    function requestAuth(redirect){
+
+        var signIn;
+        if(redirect)
+            signIn = firebase.auth().signInWithRedirect(provider)
+        else
+            signIn = firebase.auth().signInWithPopup(provider)
+
+        return signIn.then(function(result) {
             
             var token = result.credential.accessToken;
             

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -18,18 +18,17 @@ window.AuthService = (function(){
         unsubscribe();
     });
 
-    function requestAuth(redirect){
+    function requestAuth(){
 
         var signIn;
-        if(redirect)
-            signIn = firebase.auth().signInWithRedirect(provider)
-        else
+        if(this.event && this.event.type === 'click')
             signIn = firebase.auth().signInWithPopup(provider)
+        else
+            signIn = firebase.auth().signInWithRedirect(provider)
 
         return signIn.then(function(result) {
             
             var token = result.credential.accessToken;
-            
             return result.user;
             
         }).catch(function(error) {

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -39,6 +39,7 @@ body
         page-break-inside: avoid;           /* Theoretically FF 20+ */
         break-inside: avoid-column;         /* IE 11 */
         display:table;                      /* Actually FF 20+ */
+        transform: translateZ(0);           /* Seems a bit of a hack, but fixes the issue with clipped shadows in columns in Chromium browsers - @rdunn418 */
     }
 }
 

--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -10,6 +10,7 @@ body
         box-sizing: border-box;
         height: 70px;
         box-shadow: rgba(0, 0, 0, 0.4) 0 0 5px;
+        z-index: 1; /* Ensure navbar stuff appears on top of other elements when using the drop shadow bug fix - @rdunn418 */
 
         .logo 
         {


### PR DESCRIPTION
I added grunt-sass-globbing fix to allow for auto importing of scss files by importing a whole folder of files with one short single statement instead of having to add multiple scss files individually within the styles.scss sheet.

Details of the fix are under url:   https://www.npmjs.com/package/grunt-sass-globbing/v/1.0.3